### PR TITLE
rank=-1 bug on rank 0, return terminate/msg flags in wait_on_probe

### DIFF
--- a/libcircle/token.c
+++ b/libcircle/token.c
@@ -205,7 +205,7 @@ inline void
 CIRCLE_get_next_proc(CIRCLE_state_st* st)
 {
     do {
-        st->next_processor = rand() % st->size;
+        st->next_processor = rand_r(&st->seed) % st->size;
     }
     while(st->next_processor == st->rank);
 }
@@ -487,7 +487,7 @@ void CIRCLE_send_work_to_many(CIRCLE_internal_queue_t* qp, \
     else { /* CIRCLE_SPLIT_RANDOM */
         /* randomly pick a total amount to send to requestors,
          * but keep at least one item */
-        int send_count = (rand() % qp->count) + 1;
+        int send_count = (rand_r(&st->seed) % qp->count) + 1;
         if (send_count == qp->count) {
             send_count--;
         }

--- a/libcircle/token.h
+++ b/libcircle/token.h
@@ -66,6 +66,7 @@ typedef struct CIRCLE_state_st {
 
     uint32_t rank;
     uint32_t size;
+    unsigned seed;
     uint32_t next_processor;
     uint32_t offset_count;
     uint32_t* work_offsets;

--- a/libcircle/worker.c
+++ b/libcircle/worker.c
@@ -279,12 +279,12 @@ int8_t CIRCLE_worker()
     MPI_Comm_create_errhandler(CIRCLE_MPI_error_handler, &circle_err);
     MPI_Comm_set_errhandler(*mpi_s.work_comm, circle_err);
     rank = CIRCLE_global_rank;
-    srand(rank);
     local_state.rank = rank;
     local_state.token_partner_recv = (rank - 1 + size) % size;
     local_state.token_partner_send = (rank + 1 + size) % size;
 
     /* randomize the first task we will request work from */
+    local_state.seed = (unsigned) rank;
     CIRCLE_get_next_proc(&local_state);
 
     /* Initial local state */


### PR DESCRIPTION
I'm also debugging a hang on our system.  I have a deadlock case where a process gets stuck in the Issend while sending work to a rank that is not responding, because it has already received the termination message.  Of course it shouldn't have gotten the termination message if there is still work to do.  I think this was happening because the token_partner for rank 0 is computed as (rank - 1) % size --> -1, which happens to be MPI_PROC_NULL.  Thus, it immediately can receive the token (a receive from PROC_NULL always succeeds) and so rank 0 thinks that signal travelled around the whole ring.  A simple change to (rank - 1 + size) % size seemed to do the trick, but I'm still testing to be sure.

While debugging this, I came across another possible bug in that size returns either TERMINATION, the output from MPI_Get_count, or 0.  The problem is that MPI_Get_count can sometimes return MPI_UNDEFINED, which can be any arbitrary negative value (which might happen to equal the value used for TERMINATION).  Thus, I've changed the prototype on this function to set a flag for termination and another flag to indicate a message is ready for receiving.  In the case that a message is ready, it also returns the status from the Iprobe.  Then the size can be computed external to the wait_for_probe() function.

Also, in my tracing, I could see cases where processes sometimes transfer all of their work to the requestor process.  This is somewhat inefficient since after communication, the net effect is just to swap the role of the two processes.  I'll modify this, so that the process with work always keeps at least one element.
