### PR TITLE
fixed configure --disable-{tests,doxygen}

### DIFF
--- a/m4/lx_find_check.m4
+++ b/m4/lx_find_check.m4
@@ -3,9 +3,14 @@ AC_DEFUN([X_AC_LIBCIRCLE_CHECK], [
   AC_ARG_ENABLE(
     [tests],
     AS_HELP_STRING(--enable-tests, enable the unit tests),
-    [ PKG_CHECK_MODULES([CHECK], [check >= 0.9.4])
-      x_ac_libcircle_check=yes
-    ],
+    [AS_IF([test "x$enable_tests" != "xno"],
+        [ PKG_CHECK_MODULES([CHECK], [check >= 0.9.4])
+          x_ac_libcircle_check=yes
+        ],
+	[
+           x_ac_libcircle_check=no
+	]
+    )],
     [
       x_ac_libcircle_check=no
     ]

--- a/m4/lx_find_doxygen.m4
+++ b/m4/lx_find_doxygen.m4
@@ -3,9 +3,14 @@ AC_DEFUN([X_AC_LIBCIRCLE_DOXYGEN], [
   AC_ARG_ENABLE(
     [doxygen],
     AS_HELP_STRING(--enable-doxygen, enable doxygen),
-    [ AC_CHECK_PROGS([DOXYGEN], [doxygen])
-      x_ac_libcircle_doxygen=yes
-    ],
+    [AS_IF([test "x$enable_doxygen" != "xno"],
+        [ AC_CHECK_PROGS([DOXYGEN], [doxygen])
+          x_ac_libcircle_doxygen=yes
+        ],
+        [
+          x_ac_libcircle_doxygen=no
+        ]
+    )],
     [
       x_ac_libcircle_doxygen=no
     ]


### PR DESCRIPTION
./configure --disable-tests enabled tests, too. Same for --disable-doxygen.

The problem is that the 1st argument of AC_ARG_ENABLE, is also executed with --disable-xxx.

See the warning about the usage in this guide:
https://www.flameeyes.eu/autotools-mythbuster/autoconf/arguments.html
