### PR TITLE
add cleanup for tree termination to support abort

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,9 +41,9 @@ AC_SUBST([LIBCIRCLE_API_VERSION], [0.2.2])
 
 # Allow user to switch to tree-based termination
 AC_ARG_ENABLE([treeterm],
-  AS_HELP_STRING(--enable-treeterm, [switch to tree-based termination (improved scalability, but abort and checkpoint not supported)]),
+  AS_HELP_STRING(--enable-treeterm, [switch to tree-based termination for improved scalability]),
   [case "${enableval}" in
-   yes) AC_DEFINE(USE_TREETERM, 1, [tree-based termination for improved scalability, but abort and checkpoint are not supported])
+   yes) AC_DEFINE(USE_TREETERM, 1, [tree-based termination for improved scalability])
         x_ac_libcircle_treeterm=yes ;;
    no)  x_ac_libcircle_treeterm=no ;;
    *) AC_MSG_ERROR([bad value ${enableval} for --enable-treeterm]) ;;

--- a/libcircle/token.h
+++ b/libcircle/token.h
@@ -90,9 +90,9 @@ typedef struct CIRCLE_state_st {
 
     /* manage state for termination allreduce operations */
     int work_outstanding; /* counter to track number of outstanding work transfer messages */
-    int term_flag;    /* whether we have sent work to anyone since last allreduce */
-    int term_up;      /* flag indicating whether we have sent message to parent */
-    int term_replies; /* keeps count of number of chidren who have replied */
+    int term_flags[2];    /* whether we have sent work to anyone since last allreduce */
+    int term_up;          /* flag indicating whether we have sent message to parent */
+    int term_replies;     /* keeps count of number of chidren who have replied */
 
     /* profiling counters */
     int32_t local_objects_processed; /* number of locally completed work items */
@@ -127,7 +127,7 @@ void CIRCLE_token_check(CIRCLE_state_st* st);
 
 int  CIRCLE_check_for_term(CIRCLE_state_st* st);
 
-int  CIRCLE_check_for_term_allreduce(CIRCLE_state_st* st);
+int  CIRCLE_check_for_term_allreduce(CIRCLE_state_st* st, int cleanup);
 
 void CIRCLE_workreceipt_check(CIRCLE_internal_queue_t* queue,
                           CIRCLE_state_st* state);


### PR DESCRIPTION
This PR is meant to cleanup termination tree messages in the case that a process bailed out early with messages still in flight due to an abort signal.  This needs more testing with abort and non-abort cases before being merged.