### PR TITLE
fix: honor MPI_Send size limit in CIRCLE_send_work

### DIFF
--- a/libcircle/token.c
+++ b/libcircle/token.c
@@ -1393,7 +1393,30 @@ static int CIRCLE_send_work(CIRCLE_internal_queue_t* qp, CIRCLE_state_st* st, \
     size_t len = end_offset - start_offset;
     len += strlen(qp->base + end_offset) + 1;
 
-    /* TODO: check that len doesn't overflow an int */
+    /* If total byte count exceeds the length MPI_Send can handle
+     * then back off by reducing the number of items to send; the
+     * remaining items stay in our queue and will be sent later. */
+    while(len > INT32_MAX && count > 1) {
+        int32_t next = count - (count / 10);
+        if(next >= count) {
+            next = count - 1;
+        }
+
+        count = next;
+        start_elem = qp->count - count;
+        start_offset = qp->strings[start_elem];
+        len = end_offset - start_offset;
+        len += strlen(qp->base + end_offset) + 1;
+    }
+
+    if(len > INT32_MAX) {
+        LOG(CIRCLE_LOG_ERR,
+            "Single work item too large to send (%zu bytes).", len);
+        CIRCLE_send_no_work(dest);
+        return -1;
+    }
+
+    /* this cast is safe because we ensured len <= INT32_MAX */
     int bytes = (int) len;
 
     /* total number of ints we'll send */


### PR DESCRIPTION
In an extremely unbalanced job where some of the workers get bogged down, the amount of data one task may collect can balloon to the point it will not fit into the MPI_Send as a buffer which has an int32 size limit.  There was a `TODO` in the code in this area which this pull request fixes.

The failure looks like this (I added a backtrace so I could find the root cause):

```
libcircle/worker.c:57:MPI Error in Comm [Libcircle Work Comm]: MPI_ERR_COUNT: invalid count argument
libcircle/worker.c:62:Stack trace (11 frames):
libcircle/worker.c:64:  #0 /usr/local/lib/libcircle.so.2(+0x6f6c) [0x4000008c6f6c]
libcircle/worker.c:64:  #1 /usr/lib/aarch64-linux-gnu/libmpi.so.40(ompi_errhandler_invoke+0x23c) [0x40000025659c]
libcircle/worker.c:64:  #2 /usr/lib/aarch64-linux-gnu/libmpi.so.40(MPI_Send+0x1cc) [0x4000002b1f2c]
libcircle/worker.c:64:  #3 /usr/local/lib/libcircle.so.2(CIRCLE_workreq_check+0x390) [0x4000008c6938]
libcircle/worker.c:64:  #4 /usr/local/lib/libcircle.so.2(CIRCLE_worker+0x260) [0x4000008c7400]
libcircle/worker.c:64:  #5 /usr/local/lib/libmfu.so.4.0.0(mfu_flist_walk_paths+0x164) [0x4000000aa730]
libcircle/worker.c:64:  #6 /usr/local/lib/libmfu.so.4.0.0(mfu_flist_walk_param_paths+0x94) [0x4000000aaae0]
libcircle/worker.c:64:  #7 /usr/local/bin/dwalk(main+0x740) [0xaaaaaaaa2540]
libcircle/worker.c:64:  #8 /usr/lib/aarch64-linux-gnu/libc.so.6(+0x22f1c) [0x4000005b2f1c]
libcircle/worker.c:64:  #9 /usr/lib/aarch64-linux-gnu/libc.so.6(__libc_start_main+0x9c) [0x4000005b305c]
libcircle/worker.c:64:  #10 /usr/local/bin/dwalk(_start+0x30) [0xaaaaaaaa2cf0]
libcircle/worker.c:68:Libcircle received MPI error, checkpointing.
```

The fix is to back off while attempting to send as much as possible, but do it efficiently.  The remaining work will be sent on the next request from a peer.  While there is no unit test for this case, it was reproducible 66% of the time on a system, after which the issue has not re-appeared for at least 50 consecutive runs.