### PR TITLE
prevent deadlocks with non-blocking sends on the work sharing path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,11 +1,9 @@
 include $(top_srcdir)/common.mk
 
-SUBDIRS = doc
-
-# add in unit tests if we found libcheck
-if HAVE_CHECK
-  SUBDIRS += tests
-endif
+# tests/ holds the libcheck unit tests, which build only when libcheck
+# was found, plus the multi-rank regression test, which does not need
+# libcheck, so the directory is always visited
+SUBDIRS = doc tests
 
 AUTOMAKE_OPTIONS = subdir-objects foreign
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,10 @@ X_AC_LIBCIRCLE_PKG_CONFIG
 X_AC_LIBCIRCLE_CHECK
 AM_CONDITIONAL([HAVE_CHECK], [test x$x_ac_libcircle_check = xyes])
 
+# Launcher used by the multi-rank regression test.  That test skips
+# itself when no launcher is found, so this is not fatal.
+AC_CHECK_PROGS([MPIRUN], [mpirun mpiexec], [none])
+
 # Needed for docs
 X_AC_LIBCIRCLE_DOXYGEN
 
@@ -45,7 +49,7 @@ AC_FUNC_MALLOC
 # - Always increase the revision value.
 # - Increase the current value whenever an interface has been added, removed or changed.
 # - Increase the age value only if the changes made to the ABI are backward compatible.
-AC_SUBST([LIBCIRCLE_SO_VERSION], [3:1:1])
+AC_SUBST([LIBCIRCLE_SO_VERSION], [3:2:1])
 
 # Use Semantic Versioning for API
 #

--- a/libcircle/token.c
+++ b/libcircle/token.c
@@ -1095,6 +1095,123 @@ CIRCLE_get_next_proc(CIRCLE_state_st* st)
     }
 }
 
+/* Record a non-blocking send so that we can free its buffer once the
+ * send has completed.  Takes ownership of buf, which may be NULL for
+ * messages that carry no payload. */
+static void CIRCLE_worksend_track(CIRCLE_state_st* st, MPI_Request req, void* buf)
+{
+    /* grow our arrays if we've run out of room */
+    if(st->send_count == st->send_capacity) {
+        int capacity = (st->send_capacity > 0) ? st->send_capacity * 2 : 32;
+
+        MPI_Request* reqs = (MPI_Request*) realloc(st->send_reqs,
+                                (size_t)capacity * sizeof(MPI_Request));
+        void** bufs = (void**) realloc(st->send_bufs,
+                                (size_t)capacity * sizeof(void*));
+
+        if(reqs == NULL || bufs == NULL) {
+            LOG(CIRCLE_LOG_FATAL, "Failed to allocate memory to track sends.");
+            MPI_Abort(st->comm, LIBCIRCLE_MPI_ERROR);
+            return;
+        }
+
+        st->send_reqs     = reqs;
+        st->send_bufs     = bufs;
+        st->send_capacity = capacity;
+    }
+
+    st->send_reqs[st->send_count] = req;
+    st->send_bufs[st->send_count] = buf;
+    st->send_count++;
+
+    return;
+}
+
+/* Test each outstanding send and free the buffer of any that have
+ * completed.  This never blocks, so a process that cannot push a
+ * message out just accumulates a request here while it continues to
+ * service everyone else. */
+void CIRCLE_worksend_check(CIRCLE_state_st* st)
+{
+    /* walk the list backwards so we can swap the last entry into the
+     * slot of a completed send without disturbing entries we have yet
+     * to visit */
+    int i;
+
+    for(i = st->send_count - 1; i >= 0; i--) {
+        int flag;
+        MPI_Test(&st->send_reqs[i], &flag, MPI_STATUS_IGNORE);
+
+        if(! flag) {
+            continue;
+        }
+
+        /* send completed, so it's safe to release its buffer */
+        CIRCLE_free(&st->send_bufs[i]);
+
+        /* fill this slot with the last entry in the list */
+        st->send_count--;
+        st->send_reqs[i] = st->send_reqs[st->send_count];
+        st->send_bufs[i] = st->send_bufs[st->send_count];
+    }
+
+    return;
+}
+
+/* Wait for every outstanding send to complete and release its buffer.
+ *
+ * Only call this once the cleanup barrier has completed.  At that point
+ * every process has received everything we sent it, so these sends have
+ * all been matched and the waits return promptly.  We cannot simply
+ * abandon the requests: their buffers are not ours to free until MPI is
+ * done reading them.
+ *
+ * There is a race that makes this necessary even though the barrier is
+ * only started once we have no sends outstanding.  A process can be
+ * asked for work after it starts the barrier, and it answers with a
+ * "no work" reply.  The barrier can then complete before that reply's
+ * request has been reaped. */
+void CIRCLE_worksend_wait(CIRCLE_state_st* st)
+{
+    if(st->work_request_req != MPI_REQUEST_NULL) {
+        MPI_Wait(&st->work_request_req, MPI_STATUS_IGNORE);
+    }
+
+    if(st->send_count > 0) {
+        MPI_Waitall(st->send_count, st->send_reqs, MPI_STATUSES_IGNORE);
+
+        int i;
+
+        for(i = 0; i < st->send_count; i++) {
+            CIRCLE_free(&st->send_bufs[i]);
+        }
+
+        st->send_count = 0;
+    }
+
+    return;
+}
+
+/* free memory used to track outstanding sends */
+void CIRCLE_worksend_free(CIRCLE_state_st* st)
+{
+    /* CIRCLE_worksend_wait drains these before we get here, so anything
+     * left means we tore down early.  Don't free the buffers, since MPI
+     * may still be reading them. */
+    if(st->send_count > 0) {
+        LOG(CIRCLE_LOG_ERR, "Freeing state with %d outstanding sends.",
+            st->send_count);
+    }
+
+    CIRCLE_free(&st->send_reqs);
+    CIRCLE_free(&st->send_bufs);
+
+    st->send_count    = 0;
+    st->send_capacity = 0;
+
+    return;
+}
+
 /**
  * @brief Extend the offset arrays.
  */
@@ -1120,21 +1237,14 @@ int8_t CIRCLE_extend_offsets(CIRCLE_state_st* st, int32_t size)
     st->offsets_recv_buf = (int*) realloc(st->offsets_recv_buf,
                                           (size_t)count * sizeof(int));
 
-    st->offsets_send_buf = (int*) realloc(st->offsets_send_buf,
-                                          (size_t)count * sizeof(int));
-
     LOG(CIRCLE_LOG_DBG, "Work offsets: [%p] -> [%p]",
         (void*) st->offsets_recv_buf,
         (void*)(st->offsets_recv_buf + ((size_t)count * sizeof(int))));
 
-    LOG(CIRCLE_LOG_DBG, "Request offsets: [%p] -> [%p]",
-        (void*) st->offsets_send_buf,
-        (void*)(st->offsets_send_buf + ((size_t)count * sizeof(int))));
-
     /* record new length of offset arrays */
     st->offsets_count = count;
 
-    if(st->offsets_recv_buf == NULL || st->offsets_send_buf == NULL) {
+    if(st->offsets_recv_buf == NULL) {
         return -1;
     }
 
@@ -1248,8 +1358,10 @@ static int32_t CIRCLE_work_receive(
 
     /* send receipt back to source to notify we are now
      * accounting for this work */
-    MPI_Send(NULL, 0, MPI_BYTE, source,
-        CIRCLE_TAG_WORK_RECEIPT, comm);
+    MPI_Request req;
+    MPI_Isend(NULL, 0, MPI_BYTE, source,
+              CIRCLE_TAG_WORK_RECEIPT, comm, &req);
+    CIRCLE_worksend_track(st, req, NULL);
 
     return 0;
 }
@@ -1267,6 +1379,14 @@ int32_t CIRCLE_request_work(CIRCLE_internal_queue_t* qp, CIRCLE_state_st* st, in
 
     /* get communicator */
     MPI_Comm comm = st->comm;
+
+    /* our previous work request message may still be working its way
+     * out, we can't post another until it has gone */
+    int request_slot_free = 1;
+
+    if(st->work_request_req != MPI_REQUEST_NULL) {
+        MPI_Test(&st->work_request_req, &request_slot_free, MPI_STATUS_IGNORE);
+    }
 
     /* check whether we have a work request outstanding, and check for
      * a reply if we do, otherwise send a request so long as we're not
@@ -1296,7 +1416,7 @@ int32_t CIRCLE_request_work(CIRCLE_internal_queue_t* qp, CIRCLE_state_st* st, in
             st->work_requested = 0;
         }
     }
-    else if(!cleanup && !CIRCLE_ABORT_FLAG) {
+    else if(!cleanup && !CIRCLE_ABORT_FLAG && request_slot_free) {
         /* need to send request, get rank of process to request work from */
         int source = st->next_processor;
 
@@ -1310,10 +1430,13 @@ int32_t CIRCLE_request_work(CIRCLE_internal_queue_t* qp, CIRCLE_state_st* st, in
         /* increment number of work requests for profiling */
         st->local_work_requested++;
 
-        /* TODO: use isend to avoid deadlocks */
-        /* send work request */
-        MPI_Send(NULL, 0, MPI_BYTE, source,
-                 CIRCLE_TAG_WORK_REQUEST, comm);
+        /* send work request, this must not block: a process sitting in
+         * a blocking send services no incoming messages, which stalls
+         * every process waiting on it and can hang the whole job.  if
+         * the transport is backed up we simply stop asking for work
+         * while continuing to service everyone else */
+        MPI_Isend(NULL, 0, MPI_BYTE, source,
+                  CIRCLE_TAG_WORK_REQUEST, comm, &st->work_request_req);
 
         /* set flag and source to indicate we requested work */
         st->work_requested = 1;
@@ -1352,16 +1475,26 @@ static void spread_counts(int* sizes, int ranks, int count)
 /**
  * Sends a no work reply to someone requesting work.
  */
-void CIRCLE_send_no_work(int dest)
+void CIRCLE_send_no_work(CIRCLE_state_st* st, int dest)
 {
-    int no_work[2];
+    /* the buffer has to outlive this call, since we don't wait on the
+     * send, so allocate it and hand it off to be freed when the send
+     * completes */
+    int* no_work = (int*) malloc(2 * sizeof(int));
+
+    if(no_work == NULL) {
+        LOG(CIRCLE_LOG_FATAL, "Failed to allocate memory for a work reply.");
+        MPI_Abort(st->comm, LIBCIRCLE_MPI_ERROR);
+        return;
+    }
+
     no_work[0] = (CIRCLE_ABORT_FLAG) ? PAYLOAD_ABORT : 0;
     no_work[1] = 0;
 
-    MPI_Request r;
-    MPI_Isend(&no_work, 1, MPI_INT, dest,
-              CIRCLE_TAG_WORK_REPLY, CIRCLE_INPUT_ST.comm, &r);
-    MPI_Wait(&r, MPI_STATUS_IGNORE);
+    MPI_Request req;
+    MPI_Isend(no_work, 1, MPI_INT, dest,
+              CIRCLE_TAG_WORK_REPLY, st->comm, &req);
+    CIRCLE_worksend_track(st, req, no_work);
 }
 
 /**
@@ -1371,7 +1504,7 @@ static int CIRCLE_send_work(CIRCLE_internal_queue_t* qp, CIRCLE_state_st* st, \
                             int dest, int32_t count)
 {
     if(count <= 0) {
-        CIRCLE_send_no_work(dest);
+        CIRCLE_send_no_work(st, dest);
         /* Add cost of message */
         return 0;
     }
@@ -1399,43 +1532,57 @@ static int CIRCLE_send_work(CIRCLE_internal_queue_t* qp, CIRCLE_state_st* st, \
     /* total number of ints we'll send */
     int numoffsets = 2 + count;
 
-    /* Check to see if the offset array is large enough */
-    if(CIRCLE_extend_offsets(st, numoffsets) < 0) {
-        LOG(CIRCLE_LOG_ERR, "Error: Unable to extend offsets.");
+    /* These sends must not block.  A process that blocks in a send
+     * stops receiving, which stalls its peers and can hang the job.
+     * Since we don't wait on them, both messages are sent from buffers
+     * we allocate here rather than from the queue, whose memory is
+     * reallocated as it grows and is overwritten as soon as the next
+     * item is pushed. */
+    int* offsets = (int*) malloc((size_t)numoffsets * sizeof(int));
+    char* buf = (char*) malloc((size_t)bytes);
+
+    if(offsets == NULL || buf == NULL) {
+        LOG(CIRCLE_LOG_FATAL, "Failed to allocate memory to send work.");
+        MPI_Abort(st->comm, LIBCIRCLE_MPI_ERROR);
         return -1;
     }
 
     /* offsets[0] = number of strings */
     /* offsets[1] = number of chars being sent */
-    st->offsets_send_buf[0] = (int) count;
-    st->offsets_send_buf[1] = (int) bytes;
+    offsets[0] = (int) count;
+    offsets[1] = (int) bytes;
 
     /* now compute offset of each string */
     int32_t i = 0;
     int32_t current_elem = start_elem;
 
     for(i = 0; i < count; i++) {
-        st->offsets_send_buf[2 + i] = (int)(qp->strings[current_elem] - start_offset);
+        offsets[2 + i] = (int)(qp->strings[current_elem] - start_offset);
         current_elem++;
     }
 
-    /* TODO; use isend to avoid deadlock, but in that case, be careful
-     * to not overwrite space in queue before sends complete */
+    /* copy the items out of the queue */
+    memcpy(buf, qp->base + start_offset, (size_t)bytes);
 
     /* get communicator */
     MPI_Comm comm = st->comm;
 
+    /* MPI guarantees these are matched in the order we post them, so
+     * the receiver still gets the offsets before the data */
+    MPI_Request req;
+
     /* send item count, total bytes, and offsets of each item */
-    MPI_Send(st->offsets_send_buf, numoffsets, MPI_INT, dest,
-             CIRCLE_TAG_WORK_REPLY, comm);
+    MPI_Isend(offsets, numoffsets, MPI_INT, dest,
+              CIRCLE_TAG_WORK_REPLY, comm, &req);
+    CIRCLE_worksend_track(st, req, offsets);
 
     /* send data */
-    char* buf = qp->base + start_offset;
-    MPI_Send(buf, bytes, MPI_CHAR, dest,
-             CIRCLE_TAG_WORK_REPLY, comm);
+    MPI_Isend(buf, bytes, MPI_CHAR, dest,
+              CIRCLE_TAG_WORK_REPLY, comm, &req);
+    CIRCLE_worksend_track(st, req, buf);
 
     LOG(CIRCLE_LOG_DBG,
-        "Sent %d of %d items to %d.", st->offsets_send_buf[0], qp->count, dest);
+        "Sent %d of %d items to %d.", (int) count, qp->count, dest);
 
     /* subtract elements from our queue */
     qp->count -= count;
@@ -1581,14 +1728,25 @@ void CIRCLE_workreq_check(CIRCLE_internal_queue_t* qp, CIRCLE_state_st* st, int 
         return;
     }
 
+    /* every work transfer we post holds a copy of its items until the
+     * send completes, so stop transferring work once we have a lot of
+     * sends in flight, rather than letting a slow peer run us out of
+     * memory.  requestors we turn away simply ask again */
+    int send_backlog = (st->send_count >= 4 * st->size);
+
+    if(send_backlog) {
+        LOG(CIRCLE_LOG_DBG,
+            "Deferring work transfer, %d sends outstanding.", st->send_count);
+    }
+
     /* send work to requestors */
-    if(qp->count == 0 || cleanup || CIRCLE_ABORT_FLAG) {
+    if(qp->count == 0 || cleanup || CIRCLE_ABORT_FLAG || send_backlog) {
         /* we send "no work" messages back if we have no work,
-         * we are in a cleanup phase, or we have received an
-         * abort message */
+         * we are in a cleanup phase, we have received an
+         * abort message, or we have too many sends in flight */
         int i;
         for(i = 0; i < rcount; i++) {
-            CIRCLE_send_no_work(requestors[i]);
+            CIRCLE_send_no_work(st, requestors[i]);
         }
     }
     else {

--- a/libcircle/token.h
+++ b/libcircle/token.h
@@ -59,9 +59,8 @@ typedef struct CIRCLE_state_st {
     MPI_Request token_send_req;  /* request associated with pending receive */
 
     /* offset arrays are used to transfer length of items while sending work */
-    int offsets_count;     /* number of offsets in work and request offset arrays */
+    int offsets_count;     /* number of offsets in work offset array */
     int* offsets_recv_buf; /* buffer in which to receive an array of offsets when receiving work */
-    int* offsets_send_buf; /* buffer to specify offsets while sending work */
 
     /* these are used for persistent receives of work request messages
      * from other tasks */
@@ -74,6 +73,17 @@ typedef struct CIRCLE_state_st {
     /* manage state for requesting work from other procs */
     int work_requested;             /* flag indicating we have requested work */
     int work_requested_rank;        /* rank of process we requested work from */
+    MPI_Request work_request_req;   /* request for our outstanding work request message */
+
+    /* we never block in a send on the work transfer path, since a process
+     * that is blocked in a send stops servicing incoming messages, which
+     * stalls every other process that is waiting on it.  instead we post
+     * non-blocking sends and hold on to the request and its buffer until
+     * the send completes */
+    int send_count;         /* number of outstanding sends */
+    int send_capacity;      /* allocated length of arrays below */
+    MPI_Request* send_reqs; /* request for each outstanding send */
+    void** send_bufs;       /* buffer backing each outstanding send, may be NULL */
 
     /* tree used for collective operations */
     CIRCLE_tree_state_st tree;   /* parent and children of tree */
@@ -153,6 +163,16 @@ int  CIRCLE_check_for_term_allreduce(CIRCLE_state_st* st);
 void CIRCLE_workreceipt_check(CIRCLE_internal_queue_t* queue,
                           CIRCLE_state_st* state);
 
+/* reap any non-blocking sends that have completed, freeing their buffers */
+void CIRCLE_worksend_check(CIRCLE_state_st* state);
+
+/* wait for all outstanding sends to complete and free their buffers,
+ * only valid once the cleanup barrier has completed */
+void CIRCLE_worksend_wait(CIRCLE_state_st* state);
+
+/* free memory allocated to track outstanding sends */
+void CIRCLE_worksend_free(CIRCLE_state_st* state);
+
 void CIRCLE_workreq_check(CIRCLE_internal_queue_t* queue,
                           CIRCLE_state_st* state,
                           int cleanup);
@@ -161,7 +181,7 @@ int32_t CIRCLE_request_work(CIRCLE_internal_queue_t* queue,
                             CIRCLE_state_st* state,
                             int cleanup);
 
-void CIRCLE_send_no_work(int32_t dest);
+void CIRCLE_send_no_work(CIRCLE_state_st* state, int32_t dest);
 
 int8_t CIRCLE_extend_offsets(CIRCLE_state_st* st, int32_t size);
 

--- a/libcircle/worker.c
+++ b/libcircle/worker.c
@@ -139,7 +139,6 @@ static void CIRCLE_init_local_state(MPI_Comm comm, CIRCLE_state_st* local_state)
     /* allocate memory for our offset arrays */
     int32_t offsets = CIRCLE_INPUT_ST.queue->str_count;
     local_state->offsets_count = offsets;
-    local_state->offsets_send_buf = (int*) calloc((size_t)offsets, sizeof(int));
     local_state->offsets_recv_buf = (int*) calloc((size_t)offsets, sizeof(int));
 
     /* allocate array for work request */
@@ -152,6 +151,13 @@ static void CIRCLE_init_local_state(MPI_Comm comm, CIRCLE_state_st* local_state)
 
     /* initialize work request state */
     local_state->work_requested = 0;
+    local_state->work_request_req = MPI_REQUEST_NULL;
+
+    /* initialize state used to track non-blocking sends */
+    local_state->send_count    = 0;
+    local_state->send_capacity = 0;
+    local_state->send_reqs     = NULL;
+    local_state->send_bufs     = NULL;
 
     /* determine whether we are using tree-based or circle-based
      * termination detection */
@@ -235,8 +241,8 @@ void CIRCLE_free(void* pptr)
 static void CIRCLE_finalize_local_state(CIRCLE_state_st* local_state)
 {
     CIRCLE_tree_free(&local_state->tree);
+    CIRCLE_worksend_free(local_state);
     CIRCLE_free(&local_state->abort_req);
-    CIRCLE_free(&local_state->offsets_send_buf);
     CIRCLE_free(&local_state->offsets_recv_buf);
     CIRCLE_free(&local_state->requestors);
     return;
@@ -265,6 +271,9 @@ static void CIRCLE_work_loop(CIRCLE_state_st* sptr, CIRCLE_handle* q_handle)
 
         /* process any incoming work receipt messages */
         CIRCLE_workreceipt_check(CIRCLE_INPUT_ST.queue, sptr);
+
+        /* release buffers of any sends that have completed */
+        CIRCLE_worksend_check(sptr);
 
         /* check for incoming abort messages */
         CIRCLE_abort_check(sptr, cleanup);
@@ -376,10 +385,14 @@ static void CIRCLE_work_loop(CIRCLE_state_st* sptr, CIRCLE_handle* q_handle)
     /* clear up any MPI messages that may still be outstanding */
     while(1) {
         /* start a non-blocking barrier once we have no outstanding
-         * items */
+         * items, this includes any non-blocking send we posted, since
+         * its buffer is not ours to free until the send completes and
+         * a stray message would confuse the next invocation */
         if(! sptr->work_requested     &&
            ! sptr->reduce_outstanding &&
            ! sptr->abort_outstanding  &&
+           sptr->send_count == 0      &&
+           sptr->work_request_req == MPI_REQUEST_NULL &&
            sptr->token_send_req == MPI_REQUEST_NULL)
         {
             CIRCLE_barrier_start(sptr);
@@ -392,6 +405,9 @@ static void CIRCLE_work_loop(CIRCLE_state_st* sptr, CIRCLE_handle* q_handle)
 
         /* send no work message for any work request that comes in */
         CIRCLE_workreq_check(CIRCLE_INPUT_ST.queue, sptr, cleanup);
+
+        /* release buffers of any sends that have completed */
+        CIRCLE_worksend_check(sptr);
 
         /* cleanup any outstanding reduction */
         if(sptr->reduce_enabled) {
@@ -418,6 +434,11 @@ static void CIRCLE_work_loop(CIRCLE_state_st* sptr, CIRCLE_handle* q_handle)
             }
         }
     }
+
+    /* The barrier has completed, so every process has received
+     * everything we sent it.  Collect our sends and release their
+     * buffers before we go any further. */
+    CIRCLE_worksend_wait(sptr);
 
     /* execute final, synchronous reduction if enabled, this ensures
      * that we fire at least one reduce and one with the final result */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,10 @@
-TESTS = check_queue #check_checkpoint
-check_PROGRAMS = check_queue #check_checkpoint
+TESTS =
+check_PROGRAMS =
+
+# libcheck based unit tests, only built when libcheck was found
+if HAVE_CHECK
+TESTS += check_queue #check_checkpoint
+check_PROGRAMS += check_queue #check_checkpoint
 
 check_queue_SOURCES = check_queue.c $(top_srcdir)/libcircle/libcircle.h
 check_queue_CFLAGS = -I$(top_srcdir)/libcircle/ @CHECK_CFLAGS@
@@ -8,3 +13,22 @@ check_queue_LDADD = $(top_builddir)/libcircle.la @CHECK_LIBS@
 #check_checkpoint_SOURCES = check_checkpoint.c $(top_srcdir)/libcircle.h
 #check_checkpoint_CFLAGS = -I$(top_srcdir)/libcircle/ @CHECK_CFLAGS@
 #check_checkpoint_LDADD = $(top_builddir)/libcircle.la @CHECK_LIBS@
+endif
+
+# Regression test for blocking sends on the work transfer path.  Needs
+# an MPI launcher rather than libcheck; the script skips itself when
+# there is no launcher to run.
+TESTS += deadlock_test.sh
+check_PROGRAMS += check_deadlock
+
+check_deadlock_SOURCES = check_deadlock.c $(top_srcdir)/libcircle/libcircle.h
+check_deadlock_CFLAGS = -I$(top_srcdir)/libcircle/ $(MPI_CFLAGS)
+check_deadlock_LDADD = $(top_builddir)/libcircle.la $(MPI_CLDFLAGS)
+
+check_SCRIPTS = deadlock_test.sh
+CLEANFILES = deadlock_test.sh
+EXTRA_DIST = deadlock_test.sh.in
+
+deadlock_test.sh: deadlock_test.sh.in Makefile
+	$(AM_V_GEN)sed -e 's|@MPIRUN[@]|$(MPIRUN)|g' $(srcdir)/deadlock_test.sh.in > $@
+	@chmod +x $@

--- a/tests/check_deadlock.c
+++ b/tests/check_deadlock.c
@@ -1,0 +1,160 @@
+/**
+ * @file
+ *
+ * Regression test for the blocking sends that used to live on the work
+ * transfer path.
+ *
+ * A process that blocks in an MPI send stops servicing incoming
+ * messages, which stalls every process waiting on it.  Two ways that
+ * used to hang a job:
+ *
+ *   1. The work reply is large enough to go rendezvous, so the send
+ *      does not complete until the peer posts a matching receive.  Any
+ *      cycle in the "who asked whom for work" graph whose members all
+ *      hold work at the time they service the request deadlocks.  The
+ *      graph is built from random choices, so cycles are the norm.
+ *
+ *   2. Even a tiny send blocks when the transport is backed up.  The
+ *      process then stops receiving, which backs up its own peers, and
+ *      the stall spreads until the termination allreduce can no longer
+ *      complete.
+ *
+ * This test drives the pattern that produces case 1: each process
+ * repeatedly empties its queue, asks for work, refills, and then
+ * services the request that arrived while it was busy.  Run it with a
+ * tiny eager limit (see deadlock_test.sh) so that essentially every
+ * work reply goes rendezvous, and the hang shows up in seconds.  The
+ * driver script imposes the timeout; this program only checks that
+ * every item that was created also got processed.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libcircle.h"
+
+/* Length of each work item.  Long items make the data portion of a
+ * work reply large, which is what pushes it past the eager limit. */
+#define ITEM_LEN 900
+
+/* Number of items rank 0 seeds the queue with. */
+#define SEED_ITEMS 2000
+
+/* Stop creating new work once this many items have been processed
+ * locally.  Every process applies this independently, so the job ends
+ * after roughly ranks * ITEM_BUDGET items. */
+#define ITEM_BUDGET 4000
+
+/* Number of items to enqueue for each one we process, while we are
+ * still under budget.  Greater than one so queues keep refilling and
+ * work keeps being redistributed. */
+#define FANOUT 2
+
+static long items_processed;
+static long items_created;
+
+static void make_item(char* buf, long id)
+{
+    int n = snprintf(buf, ITEM_LEN, "/deadlock/test/item/%ld/", id);
+
+    /* snprintf returns what it would have written, so clamp it */
+    if(n < 0) {
+        n = 0;
+    }
+    else if(n > ITEM_LEN - 1) {
+        n = ITEM_LEN - 1;
+    }
+
+    /* pad out to ITEM_LEN so the transfers are big */
+    memset(buf + n, 'x', (size_t)(ITEM_LEN - 1 - n));
+    buf[ITEM_LEN - 1] = '\0';
+}
+
+static void create_work(CIRCLE_handle* handle)
+{
+    char item[ITEM_LEN];
+    long i;
+
+    for(i = 0; i < SEED_ITEMS; i++) {
+        make_item(item, i);
+        handle->enqueue(item);
+        items_created++;
+    }
+}
+
+static void process_work(CIRCLE_handle* handle)
+{
+    char item[CIRCLE_MAX_STRING_LEN];
+
+    if(handle->dequeue(item) < 0) {
+        return;
+    }
+
+    items_processed++;
+
+    if(items_processed >= ITEM_BUDGET) {
+        /* we've done our share, stop making more work so the job can
+         * drain and terminate */
+        return;
+    }
+
+    int i;
+
+    for(i = 0; i < FANOUT; i++) {
+        char next[ITEM_LEN];
+        make_item(next, items_created);
+        handle->enqueue(next);
+        items_created++;
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    int rank, ranks;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &ranks);
+
+    /* the flags mpifileutils uses */
+    CIRCLE_init(argc, argv, CIRCLE_SPLIT_EQUAL | CIRCLE_TERM_TREE);
+    CIRCLE_enable_logging(CIRCLE_LOG_ERR);
+
+    CIRCLE_cb_create(&create_work);
+    CIRCLE_cb_process(&process_work);
+
+    /* If the library still blocks in a send, this call never returns
+     * on at least one process and the driver script kills the job on
+     * its timeout. */
+    CIRCLE_begin();
+
+    CIRCLE_finalize();
+
+    /* every item that was created must have been processed exactly
+     * once, no matter which process ended up doing it */
+    long total_created = 0;
+    long total_processed = 0;
+    MPI_Reduce(&items_created, &total_created, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&items_processed, &total_processed, 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+
+    int rc = 0;
+
+    if(rank == 0) {
+        printf("ranks %d created %ld processed %ld\n",
+               ranks, total_created, total_processed);
+
+        if(total_created != total_processed) {
+            fprintf(stderr, "FAIL: created %ld items but processed %ld\n",
+                    total_created, total_processed);
+            rc = 1;
+        }
+    }
+
+    MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+    MPI_Finalize();
+
+    return rc;
+}

--- a/tests/deadlock_test.sh.in
+++ b/tests/deadlock_test.sh.in
@@ -1,0 +1,73 @@
+#!/bin/sh
+#
+# Run check_deadlock under a tiny eager limit so that essentially every
+# message goes rendezvous.  A rendezvous send does not complete until
+# the peer posts a matching receive, so if libcircle blocks anywhere on
+# the work transfer path, a cycle in the work request graph hangs the
+# job and the timeout below fires.
+#
+# Exits 77 (automake SKIP) when there is nothing to run with.
+
+MPIRUN="@MPIRUN@"
+RANKS="${LIBCIRCLE_TEST_RANKS:-16}"
+TIMEOUT="${LIBCIRCLE_TEST_TIMEOUT:-180}"
+PROG="./check_deadlock"
+
+if [ ! -x "$PROG" ]; then
+    echo "SKIP: $PROG was not built"
+    exit 77
+fi
+
+if [ -z "$MPIRUN" ] || [ "$MPIRUN" = "none" ] || ! command -v "$MPIRUN" >/dev/null 2>&1; then
+    echo "SKIP: no MPI launcher available"
+    exit 77
+fi
+
+# Force rendezvous for all but the smallest messages.  Each MPI
+# implementation ignores the other's settings.
+#
+# Open MPI
+OMPI_MCA_btl_self_eager_limit=128
+OMPI_MCA_btl_sm_eager_limit=128
+OMPI_MCA_btl_vader_eager_limit=128
+OMPI_MCA_btl_tcp_eager_limit=128
+export OMPI_MCA_btl_self_eager_limit OMPI_MCA_btl_sm_eager_limit
+export OMPI_MCA_btl_vader_eager_limit OMPI_MCA_btl_tcp_eager_limit
+
+# MPICH
+MPIR_CVAR_CH3_EAGER_MAX_MSG_SIZE=128
+MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=128
+export MPIR_CVAR_CH3_EAGER_MAX_MSG_SIZE MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE
+
+# We ask for more ranks than the machine is likely to have cores.
+# Open MPI 4 and Open MPI 5 spell this differently; both are harmless
+# to the other, and to MPICH.
+OMPI_MCA_rmaps_base_oversubscribe=1
+PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
+export OMPI_MCA_rmaps_base_oversubscribe PRTE_MCA_rmaps_default_mapping_policy
+
+# Running as root in a container needs this for Open MPI.
+if [ "$(id -u)" = "0" ]; then
+    OMPI_ALLOW_RUN_AS_ROOT=1
+    OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    export OMPI_ALLOW_RUN_AS_ROOT OMPI_ALLOW_RUN_AS_ROOT_CONFIRM
+fi
+
+echo "running $RANKS ranks, timeout ${TIMEOUT}s, eager limit 128 bytes"
+
+if command -v timeout >/dev/null 2>&1; then
+    timeout -s KILL "$TIMEOUT" "$MPIRUN" -n "$RANKS" "$PROG"
+    rc=$?
+else
+    echo "WARNING: no timeout(1), a hang will not be caught automatically"
+    "$MPIRUN" -n "$RANKS" "$PROG"
+    rc=$?
+fi
+
+if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+    echo "FAIL: job did not finish within ${TIMEOUT}s, libcircle is deadlocked"
+    echo "      collect stacks with: gdb -p <pid> -batch -ex 'bt full'"
+    exit 1
+fi
+
+exit "$rc"


### PR DESCRIPTION
A process blocked in MPI_Send stops servicing incoming messages, so one stall spreads to every peer waiting on it.  Peers are picked at random, and the work request graph regularly contains cycles as a result, so a cycle of rendezvous-sized work replies deadlocks outright.

This change will ensure that libcircle based algorithms will not form deadlock cycles when one rank spends significant time processing and cannot return to service network requests from peers.  There was a todo in the area of this code.  We now post these sends with MPI_Isend.  The queue cannot back an unwaited send, since it is reallocated as it grows and overwritten by the next push, so each transfer is sent from its own buffer and released when the send completes.  This does increase memory usage slightly but this trade-off is worth avoiding the deadlock.

In a live environment where one rank gets blocked for a very long time in a syscall (in this case due to ldlm lock acquisition retrying after timing out until a client holding that lock was drained):

Before: work went effectively single-rank 1.5 hours into the run. 389 of 960 instrumented 30 second time windows had zero ranks making progress, including the final 192 minutes, which ran on at zero throughput until the scheduler killed the job at its time limit.  (This is because the lock issue persisted throughout the job)

After: none of 381 sampled windows had no ranks making progress: one rank sat inside a callback, outside MPI, for 2 hours 53 minutes. The other 127 ranks kept working around it whereas before they ended up in a deadlock.  Once the livelock was resolved in the live environment, it could complete by finishing the work within that one worker.